### PR TITLE
feat: option for logging chromium debug messages

### DIFF
--- a/context.go
+++ b/context.go
@@ -23,6 +23,7 @@ var (
 type BrowserContext struct {
 	IdleType        string
 	BrowserExecPath string
+	ChromiumDebug   bool
 	DebugMode       bool
 	Container       bool
 }

--- a/examples/pdf/main.go
+++ b/examples/pdf/main.go
@@ -28,6 +28,8 @@ func main() {
 		"indicate if running in container (docker / lambda) environment",
 	)
 	debug := flag.Bool("debug", false, "turn on for outputing debug message")
+	chromiumDebug := flag.Bool("chromiumDebug", false, "turn on for chrome debug message output")
+
 	flag.Parse()
 
 	if *paperWidth < 0 || *paperHeight < 0 {
@@ -54,6 +56,7 @@ func main() {
 		IdleType:        *idleType,
 		BrowserExecPath: *browserExecPath,
 		Container:       *container,
+		ChromiumDebug:   *chromiumDebug,
 		DebugMode:       *debug,
 	}
 

--- a/examples/render/main.go
+++ b/examples/render/main.go
@@ -27,6 +27,7 @@ func main() {
 		"indicate if running in container (docker / lambda) environment",
 	)
 	debug := flag.Bool("debug", false, "turn on for outputing debug message")
+	chromiumDebug := flag.Bool("chromiumDebug", false, "turn on for chromium debug message output")
 
 	flag.Parse()
 
@@ -54,6 +55,7 @@ func main() {
 		IdleType:        *idleType,
 		BrowserExecPath: *browserExecPath,
 		Container:       *container,
+		ChromiumDebug:   *chromiumDebug,
 		DebugMode:       *debug,
 	}
 

--- a/renderer.go
+++ b/renderer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"time"
 
@@ -71,7 +72,11 @@ func RenderPdf(ctx context.Context, urlStr string) ([]byte, error) {
 	start := time.Now()
 	ctx, cancel := chromedp.NewExecAllocator(ctx, opts...)
 	defer cancel()
-	ctx, cancel = chromedp.NewContext(ctx)
+	if browserContext.ChromiumDebug {
+		ctx, cancel = chromedp.NewContext(ctx, chromedp.WithDebugf(log.Printf))
+	} else {
+		ctx, cancel = chromedp.NewContext(ctx)
+	}
 	defer cancel()
 
 	var res []byte
@@ -158,7 +163,11 @@ func RenderPage(ctx context.Context, urlStr string) ([]byte, error) {
 	start := time.Now()
 	ctx, cancel := chromedp.NewExecAllocator(ctx, opts...)
 	defer cancel()
-	ctx, cancel = chromedp.NewContext(ctx)
+	if browserContext.ChromiumDebug {
+		ctx, cancel = chromedp.NewContext(ctx, chromedp.WithDebugf(log.Printf))
+	} else {
+		ctx, cancel = chromedp.NewContext(ctx)
+	}
 	defer cancel()
 
 	var res string
@@ -343,6 +352,6 @@ func cmToInch(cm float64) float64 {
 // debugMessage print out msg if debugMode is true
 func debugMessage(debugMode bool, msg string) {
 	if debugMode {
-		fmt.Printf("%s\n", msg)
+		log.Printf("%s\n", msg)
 	}
 }


### PR DESCRIPTION
# Description
Adding `ChromiumDebug` context flag to enable showing chromium execution message for debugging