### PR TITLE
feat: add user-agent option to enable setting custom user-agent value

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Renderer options values:
   with idleType=networkIdle (Use on page with protection like CloudFlare)
   - Type: Int
   - Default: 0
+- `UserAgent`: Set custom user agent value
+  - Type: string
+  - Default: Empty string (Will user default user agent of the browser)
 
 **Note:** Default renderer option `defaultRendererOption` will be used if not set no explicit option is set.
 
@@ -72,7 +75,6 @@ go build
 
 ```
 Usage: ./render <url>
-./render url
   -bHeight int
         height of browser window's size (default 1080)
   -bWidth int
@@ -95,6 +97,8 @@ Usage: ./render <url>
         skip first n frames with same id as init frame, only valid with idleType=networkIdle
   -timeout int
         seconds before timeout when rendering (default 30)
+  -userAgent string
+        set custom user agent for sending request in automation browser
 ```
 
 ### Render PDF

--- a/examples/render/main.go
+++ b/examples/render/main.go
@@ -27,6 +27,11 @@ func main() {
 	)
 	debug := flag.Bool("debug", false, "turn on for outputing debug message")
 	chromiumDebug := flag.Bool("chromiumDebug", false, "turn on for chromium debug message output")
+	userAgent := flag.String(
+		"userAgent",
+		"",
+		"set custom user agent for sending request in automation browser",
+	)
 
 	flag.Parse()
 
@@ -74,6 +79,7 @@ func main() {
 		Timeout:        *timeout,
 		ImageLoad:      *imageLoad,
 		SkipFrameCount: *skipFrameCount,
+		UserAgent:      *userAgent,
 	})
 	if err != nil {
 		logger.Error(fmt.Sprintf("Render test: %s", err))

--- a/option.go
+++ b/option.go
@@ -29,6 +29,7 @@ type RendererOption struct {
 	Timeout        int
 	ImageLoad      bool
 	SkipFrameCount int
+	UserAgent      string
 }
 
 var defaultRendererOption = RendererOption{

--- a/renderer.go
+++ b/renderer.go
@@ -68,6 +68,10 @@ func (r *Renderer) RenderPage(urlStr string, opts *RendererOption) ([]byte, erro
 		)
 	}
 
+	if opts.UserAgent != "" {
+		chromeOpts = append(chromeOpts, chromedp.UserAgent(opts.UserAgent))
+	}
+
 	chromeOpts = append(
 		chromeOpts,
 		chromedp.Flag("blink-settings", fmt.Sprintf("imagesEnbled=%t", opts.ImageLoad)),
@@ -114,7 +118,7 @@ func (r *Renderer) RenderPage(urlStr string, opts *RendererOption) ([]byte, erro
 	return []byte(resp), nil
 }
 
-// RenderPdf generate and return the pdf as byte array from the given url using 
+// RenderPdf generate and return the pdf as byte array from the given url using
 // automated chrome browser. PdfOption is for setting the style of the generated pdf.
 func (r *Renderer) RenderPdf(urlStr string, opts *PdfOption) ([]byte, error) {
 	pdfParams := page.PrintToPDF()
@@ -272,4 +276,3 @@ func (r *Renderer) isInteractiveTime(e *page.EventLifecycleEvent) bool {
 func cmToInch(cm float64) float64 {
 	return math.Round((cm/2.54)*100) / 100
 }
-


### PR DESCRIPTION
# Description
Enable setting custom `User-Agent` header with `UserAgent` field in `RendererOption`

Resolves #39 