### PR TITLE
feat: new idleType option `auto`

### DIFF
--- a/examples/pdf/main.go
+++ b/examples/pdf/main.go
@@ -18,8 +18,8 @@ func main() {
 	marginBottom := flag.Float64("marginBottom", 1, "bottom margin in centimeter")
 	marginLeft := flag.Float64("marginLeft", 1, "left margin in centimeter")
 	marginRight := flag.Float64("marginRight", 1, "right margin in centimeter")
-	idleType := flag.String("idleType", "networkIdle",
-		"how to determine loading idle and return, valid input: networkIdle, InteractiveTime")
+	idleType := flag.String("idleType", "auto",
+		"how to determine loading idle and return, valid input: auto, networkIdle, InteractiveTime")
 	browserExecPath := flag.String("browserPath", "", "manually set browser executable path")
 	container := flag.Bool(
 		"container",
@@ -39,7 +39,7 @@ func main() {
 		fmt.Println("Margins value should be greater than 0")
 		os.Exit(1)
 	}
-	if *idleType != "networkIdle" && *idleType != "InteractiveTime" {
+	if !renderer.IsValidIdleType(*idleType) {
 		fmt.Println("Valid idleType value: networkIdle, InteractiveTime")
 		os.Exit(1)
 	}

--- a/examples/render/main.go
+++ b/examples/render/main.go
@@ -15,8 +15,8 @@ func main() {
 	browserHeight := flag.Int("bHeight", 1080, "height of browser window's size")
 	timeout := flag.Int("timeout", 30, "seconds before timeout when rendering")
 	imageLoad := flag.Bool("imageLoad", false, "indicate if load image when rendering")
-	idleType := flag.String("idleType", "networkIdle",
-		"how to determine loading idle and return, valid input: networkIdle, InteractiveTime")
+	idleType := flag.String("idleType", "auto",
+		"how to determine loading idle and return, valid input: auto, networkIdle, InteractiveTime")
 	skipFrameCount := flag.Int("skipFrameCount", 0,
 		"skip first n frames with same id as init frame, only valid with idleType=networkIdle")
 	browserExecPath := flag.String("browserPath", "", "manually set browser executable path")
@@ -39,8 +39,8 @@ func main() {
 		fmt.Println("Browser width / height value should be greater than 0")
 		os.Exit(1)
 	}
-	if *idleType != "networkIdle" && *idleType != "InteractiveTime" {
-		fmt.Println("Valid idleType value: networkIdle, InteractiveTime")
+	if !renderer.IsValidIdleType(*idleType) {
+		fmt.Println("Valid idleType value: auto, networkIdle, InteractiveTime")
 		os.Exit(1)
 	}
 	if *skipFrameCount < 0 {

--- a/option.go
+++ b/option.go
@@ -2,16 +2,24 @@ package renderer
 
 import (
 	"log/slog"
+	"slices"
 
 	"github.com/chromedp/cdproto/page"
 )
 
 const (
-	defaultIdleType     string = "networkIdle"
+	defaultIdleType     string = "auto"
 	defaultTimeout      int    = 30
 	defaultWindowWidth  int    = 1920
 	defaultWindowHeight int    = 1080
 )
+
+// IsValidIdleType checks if the given idleType is valid
+func IsValidIdleType(idleType string) bool {
+	validTypes := []string{"auto", "networkIdle", "InteractiveTime"}
+
+	return slices.Contains(validTypes, idleType)
+}
 
 type BrowserConf struct {
 	IdleType        string


### PR DESCRIPTION
# Description
The `auto` idle type monitors both `networkIdle` and `interactiveTime`.  
The process is deemed complete as soon as **either** condition is satisfied.
